### PR TITLE
Ensure texture type is set to default

### DIFF
--- a/Editor/WoWExportUnityPostProcessor.cs
+++ b/Editor/WoWExportUnityPostProcessor.cs
@@ -40,6 +40,7 @@ public class WoWExportUnityPostprocessor : AssetPostprocessor
         }
 
         TextureImporter textureImporter = (TextureImporter)assetImporter;
+        textureImporter.textureType = TextureImporterType.Default;
         textureImporter.wrapMode = TextureWrapMode.Clamp;
         textureImporter.textureCompression = TextureImporterCompression.Uncompressed;
         textureImporter.filterMode = FilterMode.Bilinear;


### PR DESCRIPTION
I accidentally had my project set to 2D in Unity and all the textures were imported as sprites.