### PR TITLE
Ensure parsing floats works for cultures with different decimal separator

### DIFF
--- a/Editor/ItemCollectionUtility.cs
+++ b/Editor/ItemCollectionUtility.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine;
 using UnityEditor;
 using System.IO;
@@ -65,26 +66,35 @@ namespace WowUnity
 
                 Vector3 doodadPosition = Vector3.zero;
                 Quaternion doodadRotation = Quaternion.identity;
-                float doodadScale = float.Parse(fields[8]);
+                float doodadScale = float.Parse(fields[8], CultureInfo.InvariantCulture);
 
                 if (isADT(modelPlacementInformation))
                 {
 
-                    doodadPosition.x = MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[1]);
-                    doodadPosition.z = (MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[3])) * -1f;
-                    doodadPosition.y = float.Parse(fields[2]);
+                    doodadPosition.x = MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[1], CultureInfo.InvariantCulture);
+                    doodadPosition.z = (MAXIMUM_DISTANCE_FROM_ORIGIN - float.Parse(fields[3], CultureInfo.InvariantCulture)) * -1f;
+                    doodadPosition.y = float.Parse(fields[2], CultureInfo.InvariantCulture);
 
                     Vector3 eulerRotation = Vector3.zero;
-                    eulerRotation.x = float.Parse(fields[6]);
-                    eulerRotation.y = float.Parse(fields[5]) * -1 - 90;
-                    eulerRotation.z = float.Parse(fields[4]);
+                    eulerRotation.x = float.Parse(fields[6], CultureInfo.InvariantCulture);
+                    eulerRotation.y = float.Parse(fields[5], CultureInfo.InvariantCulture) * -1 - 90;
+                    eulerRotation.z = float.Parse(fields[4], CultureInfo.InvariantCulture);
 
                     doodadRotation.eulerAngles = eulerRotation;
                 }
                 else
                 {
-                    doodadPosition = new Vector3(float.Parse(fields[1]), float.Parse(fields[3]), float.Parse(fields[2]));
-                    doodadRotation = new Quaternion(float.Parse(fields[5]) * -1, float.Parse(fields[7]), float.Parse(fields[6]) * -1, float.Parse(fields[4]) * -1);
+                    doodadPosition = new Vector3(
+                        float.Parse(fields[1], CultureInfo.InvariantCulture), 
+                        float.Parse(fields[3], CultureInfo.InvariantCulture), 
+                        float.Parse(fields[2], CultureInfo.InvariantCulture)
+                    );
+                    doodadRotation = new Quaternion(
+                        float.Parse(fields[5], CultureInfo.InvariantCulture) * -1, 
+                        float.Parse(fields[7], CultureInfo.InvariantCulture), 
+                        float.Parse(fields[6], CultureInfo.InvariantCulture) * -1, 
+                        float.Parse(fields[4], CultureInfo.InvariantCulture) * -1
+                    );
                 }
 
                 SpawnDoodad(doodadPath, doodadPosition, doodadRotation, doodadScale, instantiatedPrefabGObj.transform);


### PR DESCRIPTION
I think this is the way to fix it at least. It now correctly parses these american files in my country at least where comma is normally expected as the decimal separator. I haven't tested on an american computer to verify I didn't just break it there instead :p And I'm a noob at these things. This is just based on Googling and trial and error.